### PR TITLE
[ch1] Add missing match block in the doc

### DIFF
--- a/ch1.adoc
+++ b/ch1.adoc
@@ -262,6 +262,12 @@ Here's the rest of this method:
                 },
             }
         }
+
+        match self.bytes.next() {
+            Some(Ok(_)) => unreachable!(),
+            Some(Err(error)) => Err(error.into()),
+            None => Ok(Token::Eof),
+        }
     }
 }
 ----


### PR DESCRIPTION
The block is present in lexer.rs in the `ch1` project but missing from the tutorial.